### PR TITLE
feat : modal-DefaultContent

### DIFF
--- a/components/modal/ModalContainer.module.css
+++ b/components/modal/ModalContainer.module.css
@@ -12,7 +12,6 @@
 }
 
 .container {
-  padding: 30px;
   position: relative;
   background-color: var(--gray-500);
   border-radius: 2px;

--- a/components/modal/contents/DefaultContent.jsx
+++ b/components/modal/contents/DefaultContent.jsx
@@ -1,0 +1,32 @@
+import Button from '@/components/buttons/Button';
+import styles from '@/components/modal/contents/DefaultContent.module.css';
+import classNames from 'classnames';
+
+/**
+ * @param style
+ * 1. default
+ * 2. height-375px : 로그인 모달
+ * @param title
+ * @param content
+ * @param buttonContent
+ */
+export default function DefaultContent({
+  style,
+  title,
+  content,
+  buttonContent,
+}) {
+  const contentClass = classNames({
+    [styles[style]]: style,
+  });
+
+  return (
+    <div className={contentClass}>
+      <div className={styles['title']}>{title}</div>
+      <div className={styles['content']}>{content}</div>
+      <div className={styles['button']}>
+        <Button children={buttonContent} style={'thin-main-170px'} />
+      </div>
+    </div>
+  );
+}

--- a/components/modal/contents/DefaultContent.module.css
+++ b/components/modal/contents/DefaultContent.module.css
@@ -1,0 +1,31 @@
+.default {
+  width: 560px;
+  height: 352px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.height-375px {
+  width: 560px;
+  height: 355px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 80px;
+}
+
+.content {
+  font-weight: 400;
+  margin-top: 40px;
+  color: var(--gray-300);
+}
+
+.button {
+  margin-top: 60px;
+}


### PR DESCRIPTION
## 📝작업 내용

> 기본, 로그인 알림 모달
> 모달 컨테이너 패딩30px 제거

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/ca48688d-ea95-43a0-9b77-ad144d03277a)
![image](https://github.com/user-attachments/assets/f0b97c1e-a1fc-4c54-abf0-f3244a21b8c6)
![image](https://github.com/user-attachments/assets/1301c146-e14c-43a1-be40-6bf1d92e033a)
위의 사진 예시
1. style : ex) 2종류 기본, 로그인 알림 모달
2. title : ex) 포토카드 구매
3. content : ex) [LEGENDARY | 우리집 앞마당] 2장을 구매하시겠습니까?
4. buttonContent : ex) 구매하기
