### PR TITLE
api, 리액트쿼리 수정 / 구매자 페이지 / 컴포넌트 api연결

### DIFF
--- a/components/buttons/QuantityButton.js
+++ b/components/buttons/QuantityButton.js
@@ -1,9 +1,9 @@
-import classNames from "classnames";
-import Image from "next/image";
-import styles from "./QuantityButton.module.css";
-import plus from "@/public/plus-icon.svg";
-import minus from "@/public/minus-icon.svg";
-import { useState } from "react";
+import classNames from 'classnames';
+import Image from 'next/image';
+import styles from './QuantityButton.module.css';
+import plus from '@/public/plus-icon.svg';
+import minus from '@/public/minus-icon.svg';
+import { useState } from 'react';
 
 /**
  * @param style
@@ -13,11 +13,10 @@ import { useState } from "react";
  * ex) <QuantityButton style={"width-176px"}/>
  */
 
-export default function QuantityButton({ style }) {
+export default function QuantityButton({ style, setNum, num }) {
   const QuantityWidth = classNames({
     [styles[style]]: style,
   });
-  const [num, setNum] = useState(1);
 
   const handlePlus = () => {
     setNum(num + 1);
@@ -33,14 +32,14 @@ export default function QuantityButton({ style }) {
     <div className={QuantityWidth}>
       <Image
         src={minus}
-        className={styles["sign"]}
+        className={styles['sign']}
         onClick={handleMinus}
         alt="minus"
       />
       <span>{num}</span>
       <Image
         src={plus}
-        className={styles["sign"]}
+        className={styles['sign']}
         onClick={handlePlus}
         alt="plus"
       />

--- a/components/cards/info/GradeCategory.jsx
+++ b/components/cards/info/GradeCategory.jsx
@@ -5,16 +5,47 @@ import classNames from 'classnames';
  * @param style
  * 1. small
  * 2. medium
+ * @param grade
+ * 0-COMMON, 1-RARE, 2-SUPER RARE, 3-LEGENDARY, default-등급정보없음
+ * @param genre
+ * 0-풍경, 1-인물, 2-동물, 3-정물, 4-추상, default-기타
  */
-export default function GradeCategory({ style }) {
+export default function GradeCategory({ style, grade, genre }) {
   const textStyle = classNames({
     [styles[style]]: style,
   });
+
+  const gradeText =
+    grade === 0
+      ? 'COMMON'
+      : grade === 1
+      ? 'RARE'
+      : grade === 2
+      ? 'SUPER RARE'
+      : grade === 3
+      ? 'LEGENDARY'
+      : '등급정보없음';
+
+  const genreText =
+    genre === 0
+      ? '풍경'
+      : genre === 1
+      ? '인물'
+      : genre === 2
+      ? '동물'
+      : genre === 3
+      ? '정물'
+      : genre === 4
+      ? '추상'
+      : '기타';
+
   return (
     <div className={textStyle}>
-      <div className={styles['grade']}>RARE</div>
+      <div className={styles[gradeText.replace(/\s+/g, '-').toLowerCase()]}>
+        {gradeText}
+      </div>
       <div className={styles['bar']}>|</div>
-      <div className={styles['category']}>풍경</div>
+      <div className={styles['category']}>{genreText}</div>
     </div>
   );
 }

--- a/components/cards/info/GradeCategory.module.css
+++ b/components/cards/info/GradeCategory.module.css
@@ -4,10 +4,28 @@
   gap: 15px;
 }
 
-.medium > .grade {
+.medium > .common {
+  font-size: 1.5rem;
+  font-weight: 700px;
+  color: var(--main);
+}
+
+.medium > .rare {
   font-size: 1.5rem;
   font-weight: 700px;
   color: var(--blue);
+}
+
+.medium > .super-rare {
+  font-size: 1.5rem;
+  font-weight: 700px;
+  color: var(--purple);
+}
+
+.medium > .legendary {
+  font-size: 1.5rem;
+  font-weight: 700px;
+  color: var(--pink);
 }
 
 .medium > .bar {
@@ -22,10 +40,28 @@
   color: var(--gray-300);
 }
 
-.small > .grade {
+.small > .common {
+  font-size: 1rem;
+  font-weight: 400px;
+  color: var(--main);
+}
+
+.small > .rare {
   font-size: 1rem;
   font-weight: 400px;
   color: var(--blue);
+}
+
+.small > .super-rare {
+  font-size: 1rem;
+  font-weight: 400px;
+  color: var(--purple);
+}
+
+.small > .legendary {
+  font-size: 1rem;
+  font-weight: 400px;
+  color: var(--pink);
 }
 
 .small > .bar {

--- a/components/modal/contents/CardList.jsx
+++ b/components/modal/contents/CardList.jsx
@@ -3,7 +3,13 @@ import Dropdown from '@/components/dropdowns/Dropdown';
 import Input from '@/components/inputs/Input';
 import styles from '@/components/modal/contents/CardList.module.css';
 
-export default function CardList({ title, onClick }) {
+/**
+ * - const { data, isLoading, error } = useUsersMyCardsQuery({ id }); *id = userId 현재접속중인유저 zustand관리
+ * @param data
+ * @param isLoading
+ * @param error
+ */
+export default function CardList({ data, isLoading, error, title, onClick }) {
   const grades = ['COMMON', 'RARE', 'SUPER RARE', 'LEGENDARY'];
   const genres = ['풍경', '여행', '인물', '사물'];
 

--- a/components/modal/contents/DefaultContent.jsx
+++ b/components/modal/contents/DefaultContent.jsx
@@ -15,6 +15,7 @@ export default function DefaultContent({
   title,
   content,
   buttonContent,
+  onClick,
 }) {
   const contentClass = classNames({
     [styles[style]]: style,
@@ -25,7 +26,11 @@ export default function DefaultContent({
       <div className={styles['title']}>{title}</div>
       <div className={styles['content']}>{content}</div>
       <div className={styles['button']}>
-        <Button text={buttonContent} style={'thin-main-170px'} />
+        <Button
+          text={buttonContent}
+          style={'thin-main-170px'}
+          onClick={onClick}
+        />
       </div>
     </div>
   );

--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -5,7 +5,7 @@ export async function postSignin({ email, password }) {
     const response = await renderApi.post('/auth/sign-in', { email, password });
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 }
 
@@ -18,7 +18,7 @@ export async function postSignup({ email, password, nickname }) {
     });
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 }
 
@@ -27,6 +27,6 @@ export async function postSignout() {
     const response = await renderApi.post('/auth/sign-out');
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 }

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -1,16 +1,55 @@
 import renderApi from '@/lib/api/instance';
 
 /**
- * - **보유한 카드목록, 카드상세 조회(param id)**
+ * - **보유한 포토 카드 카드상세 조회**
  * @param id : 카드 id
  */
 export async function getUsersMyCards({ id }) {
   try {
-    const endpoint = id ? `/users/my-cards/${id}}` : '/users/my-cards';
-    const response = await renderApi.get(endpoint);
+    const response = await renderApi.get(`/users/my-cards/${id}}`);
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
+  }
+}
+
+/**
+ * - **보유한 카드목록**
+ *@param sort : recent || oldest || cheapest || highest (최신순 OR 오래된 순 OR 가격 낮은 순 OR 가격 높은 순 정렬)
+  @param genre : 장르 (필터 / int로 전달)
+  @param sellout : true || false매진 여부 (필터) - 삭제 예
+  @param grade : 등급 (필터 / int로 전달)
+  @param ownerId : 판매자 ID(필터)
+  @param pageNum : 페이지 넘버(페이지네이션)
+  @param pageSize : 페이지 사이즈(페이지네이션)
+  @param keyword : 판매 포토 카드의 이름(name), 설명(description) 중 포함 단어 여부로 검색
+ */
+export async function getUsersMyCardList({
+  sort,
+  genre,
+  sellout,
+  grade,
+  ownerId,
+  pageNum,
+  pageSize,
+  keyword,
+}) {
+  try {
+    const response = await renderApi.get('/users/my-cards', {
+      params: {
+        sort,
+        genre,
+        sellout,
+        grade,
+        ownerId,
+        pageNum,
+        pageSize,
+        keyword,
+      },
+    });
+    return response;
+  } catch (error) {
+    throw error;
   }
 }
 
@@ -45,7 +84,7 @@ export async function postUsersMyCards({
     });
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 }
 
@@ -85,7 +124,7 @@ export async function getUsersShop({
     });
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 }
 
@@ -124,6 +163,6 @@ export async function getUsersExchange({
     });
     return response;
   } catch (error) {
-    console.error(error);
+    throw error;
   }
 }

--- a/lib/constant/queryKeys.js
+++ b/lib/constant/queryKeys.js
@@ -3,6 +3,7 @@
 //   };
 export const QUERY_KEYS = {
   USERS_MY_CARDS: 'usersMyCards',
+  USERS_MY_CARD_LIST: 'usersMyCardList',
   USERS_MY_CARDS_SHOP: 'usersMyCardsShop',
   USERS_MY_CARDS_EXCHANGE: 'usersMyCardsExchange',
 };

--- a/lib/reactQuery/useUsers.js
+++ b/lib/reactQuery/useUsers.js
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
   getUsersExchange,
+  getUsersMyCardList,
   getUsersMyCards,
   getUsersShop,
   postUsersMyCards,
@@ -8,7 +9,7 @@ import {
 import { QUERY_KEYS } from '../constant/queryKeys';
 
 /**
- * - **보유한 카드목록, 카드상세 조회(param id)**
+ * - **카드상세 조회**
  * - queryFn: () => getUsersMyCards({ id }),
  * @param id : 카드 id
  */
@@ -16,6 +17,54 @@ export function useUsersMyCardsQuery({ id }) {
   return useQuery({
     queryKey: [QUERY_KEYS.USERS_MY_CARDS, id],
     queryFn: () => getUsersMyCards({ id }),
+    keepPreviousData: true,
+  });
+}
+
+/**
+ * - **보유한 카드목록**
+ *@param sort : recent || oldest || cheapest || highest (최신순 OR 오래된 순 OR 가격 낮은 순 OR 가격 높은 순 정렬)
+  @param genre : 장르 (필터 / int로 전달)
+  @param sellout : true || false매진 여부 (필터) - 삭제 예
+  @param grade : 등급 (필터 / int로 전달)
+  @param ownerId : 판매자 ID(필터)
+  @param pageNum : 페이지 넘버(페이지네이션)
+  @param pageSize : 페이지 사이즈(페이지네이션)
+  @param keyword : 판매 포토 카드의 이름(name), 설명(description) 중 포함 단어 여부로 검색
+ */
+export function useUsersMyCardListQuery({
+  sort,
+  genre,
+  sellout,
+  grade,
+  ownerId,
+  pageNum,
+  pageSize,
+  keyword,
+}) {
+  return useQuery({
+    queryKey: [
+      QUERY_KEYS.USERS_MY_CARD_LIST,
+      sort,
+      genre,
+      sellout,
+      grade,
+      ownerId,
+      pageNum,
+      pageSize,
+      keyword,
+    ],
+    queryFn: () =>
+      getUsersMyCardList({
+        sort,
+        genre,
+        sellout,
+        grade,
+        ownerId,
+        pageNum,
+        pageSize,
+        keyword,
+      }),
     keepPreviousData: true,
   });
 }

--- a/pages/auth/signup.jsx
+++ b/pages/auth/signup.jsx
@@ -121,7 +121,7 @@ export default function Signup() {
         </div>
         <Button
           style={'thin-main-520px'}
-          text={'로그인'}
+          text={'가입하기'}
           onClick={handleSignup}
         />
         <div className={styles['signup-text']}>

--- a/pages/buyer/photocard/[id].module.css
+++ b/pages/buyer/photocard/[id].module.css
@@ -4,6 +4,7 @@
   align-items: center;
   gap: 60px;
   margin-top: 60px;
+  margin-bottom: 180px;
 }
 
 .market-place {
@@ -154,4 +155,17 @@
   background-color: var(--gray-400);
   margin-top: 30px;
   margin-bottom: 30px;
+}
+
+.my-suggest-container {
+  margin-top: 60px;
+}
+
+.my-suggest-card-container {
+  margin-top: 20px;
+  overflow-x: hidden;
+  padding-top: 60px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 80px;
 }


### PR DESCRIPTION
## 📝작업 내용

> api, 리액트 쿼리 수정 - getUsersMyCards를 getUsersMyCards(id조회), getUsersMyCardList(보유한 카드목록 params 조회) 2개로 분리
> 수량 버튼 상태관리 상위 컴포넌트에서 관리하도록 분리
> 등급 카테고리 컴포넌트 api 적용
> 카드리스트 컴포넌트 api 적용
> 기본 모달 컨텐츠 컴포넌트 온클릭 추가
> 회원가입 페이지 버튼 텍스트 수정
> 구매자 페이지 모달 제외 api 적용
