### PR TITLE
feat : 인스턴스 인터셉터 setError 삭제 및 각 api setError 작성

### DIFF
--- a/components/modal/contents/CardList.jsx
+++ b/components/modal/contents/CardList.jsx
@@ -8,10 +8,14 @@ import styles from "@/components/modal/contents/CardList.module.css";
  * @param title
  * @param onClick
  */
-export default function CardList({ data, title, onClick }) {
-  const grades = ["COMMON", "RARE", "SUPER RARE", "LEGENDARY"];
-  const genres = ["풍경", "여행", "인물", "사물"];
-
+export default function CardList({
+  data,
+  title,
+  onClick,
+  onChange,
+  setParams,
+}) {
+  console.log(data);
   return (
     <>
       <div className={styles["container"]}>
@@ -22,10 +26,21 @@ export default function CardList({ data, title, onClick }) {
             style={"search-modal"}
             option={"search"}
             placeholder={"검색"}
+            onChange={onChange}
           />
           <div className={styles["dropdown-container"]}>
-            <Dropdown placeholder={"등급"} style={"default"} options={grades} />
-            <Dropdown placeholder={"장르"} style={"default"} options={genres} />
+            <Dropdown
+              placeholder={"등급"}
+              style={"default"}
+              options={"grades"}
+              setParams={setParams}
+            />
+            <Dropdown
+              placeholder={"장르"}
+              style={"default"}
+              options={"genres"}
+              setParams={setParams}
+            />
           </div>
         </div>
         <div className={styles["card-list"]}>

--- a/lib/api/image.js
+++ b/lib/api/image.js
@@ -1,4 +1,7 @@
 import renderApi from "@/lib/api/instance";
+import { useErrorStore } from "@/store/useErrorStore";
+
+const { setError } = useErrorStore.getState();
 
 export const getImageUrl = async (imageFile) => {
   const formData = new FormData();
@@ -12,7 +15,7 @@ export const getImageUrl = async (imageFile) => {
     });
     return response.data;
   } catch (error) {
-    console.error("Error uploading image:", error);
+    setError(error.response.data.message, null);
     throw error;
   }
 };

--- a/lib/api/instance.js
+++ b/lib/api/instance.js
@@ -22,11 +22,10 @@ export default function renderApi(cookies = "") {
         if (!isServer) {
           setSigninError("로그인이 필요합니다.");
           setError(
-            "로그인 하시겠습니까? 다양한 서비스를 편리하게 이용하실 수 있습니다."
+            "로그인 하시겠습니까? \n 다양한 서비스를 편리하게 이용하실 수 있습니다.",
+            "/auth/signin"
           );
         }
-      } else {
-        setError(error.response.data.message);
       }
       return Promise.reject(error);
     }

--- a/lib/api/shop.js
+++ b/lib/api/shop.js
@@ -1,4 +1,7 @@
-import renderApi from './instance';
+import { useErrorStore } from "@/store/useErrorStore";
+import renderApi from "./instance";
+
+const { setError } = useErrorStore.getState();
 
 export async function getShopCards({
   sort,
@@ -11,7 +14,7 @@ export async function getShopCards({
 }) {
   try {
     const api = renderApi();
-    const response = await api.get('/shop', {
+    const response = await api.get("/shop", {
       params: {
         sort,
         genre,
@@ -24,7 +27,7 @@ export async function getShopCards({
     });
     return response.data;
   } catch (error) {
-    console.error('Error fetching shop items:', error);
+    setError(error.response.data.message, null);
     throw error;
   }
 }
@@ -35,7 +38,7 @@ export const getShopCard = async ({ shopId, cookies }) => {
     const response = await api.get(`/shop/${shopId}`);
     return response.data;
   } catch (error) {
-    console.error('Error fetching shop card:', error);
+    setError(error.response.data.message, null);
     throw error;
   }
 };
@@ -46,7 +49,7 @@ export const deleteShopCard = async (shopId) => {
     const response = await api.delete(`/shop/${shopId}`);
     return response.data;
   } catch (error) {
-    console.error('Error deleting shop card:', error);
+    console.error("Error deleting shop card:", error);
     throw error;
   }
 };
@@ -61,7 +64,7 @@ export const createShopCard = async ({
 }) => {
   try {
     const api = renderApi();
-    const response = await api.post('/shop', {
+    const response = await api.post("/shop", {
       cardId,
       salesQuantity,
       price,
@@ -71,7 +74,7 @@ export const createShopCard = async ({
     });
     return response.data;
   } catch (error) {
-    console.error('Error creating shop card:', error);
+    console.error("Error creating shop card:", error);
     throw error;
   }
 };
@@ -85,7 +88,7 @@ export const purchaseShopCard = async ({ shopId, purchaseQuantity }) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Error purchasing shop card:', error);
+    console.error("Error purchasing shop card:", error);
     throw error;
   }
 };
@@ -104,7 +107,7 @@ export const createExchangeRequest = async ({
     });
     return response.data;
   } catch (error) {
-    console.error('Error creating exchange request:', error);
+    console.error("Error creating exchange request:", error);
     throw error;
   }
 };
@@ -115,7 +118,7 @@ export const updateShopCard = async ({ shopId, updateData }) => {
     const response = await api.patch(`/shop/${shopId}`, updateData);
     return response.data;
   } catch (error) {
-    console.error('Error updating shop card:', error);
+    console.error("Error updating shop card:", error);
     throw error;
   }
 };

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -1,4 +1,7 @@
 import renderApi from "@/lib/api/instance";
+import { useErrorStore } from "@/store/useErrorStore";
+
+const { setError } = useErrorStore.getState();
 
 /**
  * - **보유한 포토 카드 카드상세 조회**
@@ -10,6 +13,7 @@ export async function getUsersMyCards({ id }) {
     const response = await api.get(`/users/my-cards/${id}`);
     return response;
   } catch (error) {
+    setError(error.response.data.message, "back");
     throw error;
   }
 }
@@ -51,6 +55,7 @@ export async function getUsersMyCardList({
     });
     return response;
   } catch (error) {
+    setError(error.response.data.message, null);
     throw error;
   }
 }
@@ -131,6 +136,7 @@ export async function getUsersShop({
     });
     return response;
   } catch (error) {
+    setError(error.response.data.message, null);
     throw error;
   }
 }
@@ -171,6 +177,7 @@ export async function getUsersExchange({
     });
     return response;
   } catch (error) {
+    setError(error.response.data.message, null);
     throw error;
   }
 }

--- a/lib/reactQuery/useAuth.js
+++ b/lib/reactQuery/useAuth.js
@@ -1,17 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
-import { postSignin, postSignout, postSignup } from '../api/auth';
-import useAuthStore from '@/store/useAuthStore';
-import { useErrorStore } from '@/store/useErrorStore';
+import { useMutation } from "@tanstack/react-query";
+import { postSignin, postSignout, postSignup } from "../api/auth";
+import useAuthStore from "@/store/useAuthStore";
+import { useErrorStore } from "@/store/useErrorStore";
 
 const { login, logout } = useAuthStore.getState();
-const { setSuccess } = useErrorStore.getState();
+const { setSuccess, setError } = useErrorStore.getState();
 
 export function usePostSignin() {
   return useMutation({
     mutationFn: ({ email, password }) => postSignin({ email, password }),
     onSuccess: (data) => {
       login(data);
-      setSuccess('로그인 되었습니다.', '/');
+      setSuccess("로그인 되었습니다.", "/");
     },
     onError: (error) => {
       console.log(error);
@@ -24,10 +24,10 @@ export function usePostSignup() {
     mutationFn: ({ email, password, nickname }) =>
       postSignup({ email, password, nickname }),
     onSuccess: () => {
-      setSuccess('회원가입 되었습니다.', '/auth/signin');
+      setSuccess("회원가입 되었습니다.", "/auth/signin");
     },
     onError: (error) => {
-      console.log(error);
+      setError(error.response.data.message, null);
     },
   });
 }
@@ -37,10 +37,10 @@ export function usePostSignout() {
     mutationFn: () => postSignout(),
     onSuccess: () => {
       logout();
-      setSuccess('로그아웃 되었습니다.', '/');
+      setSuccess("로그아웃 되었습니다.", "/");
     },
     onError: (error) => {
-      console.log(error);
+      setError(error.response.data.message, null);
     },
   });
 }

--- a/lib/reactQuery/useExchange.js
+++ b/lib/reactQuery/useExchange.js
@@ -1,21 +1,22 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation } from "@tanstack/react-query";
 import {
   acceptExchange,
   deleteExchange,
   refuseExchange,
-} from '../api/exchange';
-import { useErrorStore } from '@/store/useErrorStore';
+} from "../api/exchange";
+import { useErrorStore } from "@/store/useErrorStore";
 
-const { setSuccess } = useErrorStore.getState();
+const { setSuccess, setError } = useErrorStore.getState();
 
 // 포토카드 교환 승인
 export function useAcceptExchange() {
   return useMutation({
     mutationFn: (exchangedId) => acceptExchange({ exchangedId }),
     onSuccess: () => {
-      setSuccess('교환승인 되었습니다.', null);
+      setSuccess("교환승인 되었습니다.", null);
     },
     onError: (error) => {
+      setError(error.response.data.message, null);
     },
   });
 }
@@ -25,9 +26,10 @@ export function useRefuseExchange() {
   return useMutation({
     mutationFn: (exchangedId) => refuseExchange({ exchangedId }),
     onSuccess: () => {
-      setSuccess('교환거절 되었습니다.', null);
+      setSuccess("교환거절 되었습니다.", null);
     },
     onError: (error) => {
+      setError(error.response.data.message, null);
     },
   });
 }
@@ -37,9 +39,10 @@ export function useDeleteExchange() {
   return useMutation({
     mutationFn: ({ exchangedId }) => deleteExchange({ exchangedId }),
     onSuccess: () => {
-      setSuccess('교환취소 되었습니다.', null);
+      setSuccess("교환취소 되었습니다.", null);
     },
     onError: (error) => {
+      setError(error.response.data.message, null);
     },
   });
 }

--- a/lib/reactQuery/useNotifications.js
+++ b/lib/reactQuery/useNotifications.js
@@ -4,6 +4,9 @@ import {
   checkNotification,
   deleteNotification,
 } from "../api/notification";
+import { useErrorStore } from "@/store/useErrorStore";
+
+const { setError } = useErrorStore.getState();
 
 export const useGetMyNotificationQuery = (params) => {
   return useQuery({
@@ -18,7 +21,7 @@ export const useCheckNotification = () => {
     mutationFn: ({ notificationId }) => checkNotification({ notificationId }),
     onSuccess: () => {},
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 };
@@ -28,7 +31,7 @@ export function useDeleteNotification() {
     mutationFn: ({ notificationId }) => deleteNotification({ notificationId }),
     onSuccess: () => {},
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 }

--- a/lib/reactQuery/usePoint.js
+++ b/lib/reactQuery/usePoint.js
@@ -1,6 +1,9 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { addRandomPoint, getLastAddTime } from "../api/point";
 import { QUERY_KEYS } from "../constant/queryKeys";
+import { useErrorStore } from "@/store/useErrorStore";
+
+const { setError } = useErrorStore.getState();
 
 // 랜덤 포인트(1~3) 추가 POST
 export function useAddRandomPoint() {
@@ -10,7 +13,7 @@ export function useAddRandomPoint() {
       console.log(data);
     },
     onError: (error) => {
-      console.log(error);
+      setError(error.response.data.message, null);
     },
   });
 }

--- a/lib/reactQuery/useShop.js
+++ b/lib/reactQuery/useShop.js
@@ -10,7 +10,7 @@ import {
 } from "@/lib/api/shop.js";
 import { useErrorStore } from "@/store/useErrorStore";
 
-const { setSuccess } = useErrorStore.getState();
+const { setSuccess, setError } = useErrorStore.getState();
 
 export const useShopCards = (params) => {
   return useQuery({
@@ -33,7 +33,7 @@ export const useDeleteShopCard = () => {
       setSuccess("삭제되었습니다.", "/mygallery");
     },
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 };
@@ -60,7 +60,7 @@ export const useCreateShopCard = () => {
       setSuccess("판매등록 되었습니다.", "/mygallery");
     },
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 };
@@ -73,7 +73,7 @@ export const usePurchaseShopCard = () => {
       setSuccess("구매 되었습니다.", "/mygallery");
     },
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 };
@@ -90,7 +90,7 @@ export const useCreateExchangeRequest = () => {
       setSuccess("교환신청 되었습니다.", null);
     },
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 };
@@ -103,7 +103,7 @@ export const useUpdateShopCard = () => {
       setSuccess("수정되었습니다.", null);
     },
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 };

--- a/lib/reactQuery/useUsers.js
+++ b/lib/reactQuery/useUsers.js
@@ -9,7 +9,7 @@ import {
 import { QUERY_KEYS } from "../constant/queryKeys";
 import { useErrorStore } from "@/store/useErrorStore";
 
-const { setSuccess } = useErrorStore.getState();
+const { setSuccess, setError } = useErrorStore.getState();
 
 /**
  * - **카드상세 조회**
@@ -22,6 +22,7 @@ export function useUsersMyCardsQuery({ id }) {
     queryFn: () => getUsersMyCards({ id }),
     keepPreviousData: true,
     enabled: !!id,
+    retry: false,
   });
 }
 
@@ -109,7 +110,7 @@ export function usePostUsersMyCardsMutation() {
       setSuccess("생성되었습니다.", "/mygallery");
     },
     onError: (error) => {
-      console.error(error);
+      setError(error.response.data.message, null);
     },
   });
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,13 +1,13 @@
-import DefaultContent from '@/components/modal/contents/DefaultContent';
-import ModalContainer from '@/components/modal/ModalContainer';
+import DefaultContent from "@/components/modal/contents/DefaultContent";
+import ModalContainer from "@/components/modal/ModalContainer";
 import RandomPoint from "@/components/modal/contents/RandomPoint";
-import Nav from '@/components/nav/Nav';
-import { useErrorStore } from '@/store/useErrorStore';
+import Nav from "@/components/nav/Nav";
+import { useErrorStore } from "@/store/useErrorStore";
 import useTimerStore from "@/store/useTimerStore";
-import '@/styles/globals.css';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import "@/styles/globals.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export default function App({ Component, pageProps }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -21,13 +21,15 @@ export default function App({ Component, pageProps }) {
     redirectPath,
   } = useErrorStore();
   const router = useRouter();
-  
+
   const { pointModal, handlePointModal } = useTimerStore();
 
   const handleClick = () => {
     setSigninError(null);
     if (!redirectPath) {
       window.location.reload();
+    } else if (redirectPath === "back") {
+      router.back();
     } else if (redirectPath) {
       router.push(redirectPath);
     }
@@ -47,11 +49,11 @@ export default function App({ Component, pageProps }) {
       {(error || success) && (
         <ModalContainer onClick={handleClick}>
           <DefaultContent
-            style={'default'}
+            style={"default"}
             title={signinError}
             content={error || success}
-            buttonContent={'확인'}
-            buttonStyle={'thin-main-170px'}
+            buttonContent={"확인"}
+            buttonStyle={"thin-main-170px"}
             onClick={handleClick}
           />
         </ModalContainer>

--- a/pages/buyer/photocard/[id].jsx
+++ b/pages/buyer/photocard/[id].jsx
@@ -47,19 +47,24 @@ export default function Index({ card, exchangeList, exchangeInfo }) {
   const [exchangeModal, setExchangeModal] = useState(false);
   const [exchangeDetailModal, setExchangeDetailModal] = useState(false);
   const [description, setDescription] = useState("");
+  const [modalSearch, setModalSearch] = useState("");
   const [num, setNum] = useState(1);
+  const [params, setParams] = useState({
+    sort: "recent",
+    genre: "",
+    grade: "",
+    pageNum: 1,
+    pageSize: 9,
+    keyword: modalSearch,
+  });
 
-  const { user } = useAuthStore();
-  const { selectedCard, setSelectedCard, clearSelectedCard } =
-    useSelectedStore();
+  const { selectedCard, setSelectedCard } = useSelectedStore();
 
   const exchangeMutation = useCreateExchangeRequest();
   const exchangeCancelMutation = useDeleteExchange();
   const purchaseCardMuatation = usePurchaseShopCard();
 
-  const { data, isLoading, error } = useUsersMyCardListQuery({
-    sort: "recent",
-  });
+  const { data, isLoading, error } = useUsersMyCardListQuery(params);
 
   const purchaseModalClick = () => {
     setExchangeDetailModal(false);
@@ -223,6 +228,8 @@ export default function Index({ card, exchangeList, exchangeInfo }) {
               title={"포토카드 교환하기"}
               onClick={selectClick}
               data={data.data.cards}
+              onChange={setModalSearch}
+              setParams={setParams}
             />
           )}
         </ModalContainer>


### PR DESCRIPTION
## 📝작업 내용

> 인스턴스에 간편하게 setError 처리하였으나 이번에 발생한 문제로 리다이렉트 path 설정이 필요하여 인스턴스 인터셉터 setError 삭제하고 각 api에 setError 작성하였습니다.
> useQuery의 경우 가져다쓰는 api에 설정해줘야해서 api에 작성한 점 참고부탁드립니다.
> 기존에 계속된 오류 모달이 출력된 이유는
1. 리액트쿼리에서 실패하더라도 기본 3회 호출
2. 새로고침하더라도 예를들어 /mygallery/:id라서 계속 호출됨 => 무한반복

으로 판단됩니다. 이것의 해결방법으로

1. 리액트쿼리에서 실패하더라도 기본 3회 호출 => retry : false로 1회만 하도록 조정
2. 새로고침하더라도 예를들어 /mygallery/:id라서 계속 호출됨 => 새로고침이 아닌 특정페이지 및 뒤로가기설정

으로 생각되며 내일 아침 팀미팅때 건의드릴 예정입니다.

> 구매자 페이지 모달의 내가 보유한 포토카드 검색 및 정렬 api 붙였습니다.
